### PR TITLE
Support for `arguments` object as TypedArray constructor argument

### DIFF
--- a/src/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -6,6 +6,7 @@
 
 package org.mozilla.javascript.typedarrays;
 
+import org.mozilla.javascript.Arguments;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ExternalArrayData;
 import org.mozilla.javascript.IdFunctionObject;
@@ -156,9 +157,10 @@ public abstract class NativeTypedArrayView<T>
 
             return construct(na, byteOff, byteLen / getBytesPerElement());
 
-        } else if (args[0] instanceof NativeArray) {
+        } else if (args[0] instanceof NativeArray || args[0] instanceof Arguments) {
             // Copy elements of the array and convert them to the correct type
-            List l = (List)args[0];
+            List l = args[0] instanceof NativeArray ? (List)args[0] : 
+                Arrays.asList(ScriptRuntime.getArrayElements((Scriptable) args[0]));
             NativeArrayBuffer na = makeArrayBuffer(cx, scope, l.size() * getBytesPerElement());
             NativeTypedArrayView v = construct(na, 0, l.size());
             int p = 0;


### PR DESCRIPTION
Before the change the following would cause `org.mozilla.javascript.EcmaError: Error: invalid argument`
```
function foo() {
  return new Int32Array(arguments);
};
```

The proposed change is completely untested and should be considered more of a bug report.